### PR TITLE
Add 'include' and 'exclude' options for more fine-tuned control over brfs'd files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.js]
+trim_trailing_whitespace = false

--- a/index.js
+++ b/index.js
@@ -4,9 +4,12 @@ var through = require('through2');
 var fs = require('fs');
 var path = require('path');
 var resolve = require('resolve');
+var minimatch = require('minimatch');
 
 module.exports = function (file, opts) {
     if (/\.json$/.test(file)) return through();
+    if (opts.exclude && minimatch(file, opts.exclude)) return through();
+    if (opts.include && ! minimatch(file, opts.include)) return through();
     
     function resolver (p) {
         return resolve.sync(p, { basedir: path.dirname(file) });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "brfs": "bin/cmd.js"
   },
   "dependencies": {
+    "minimatch": "^3.0.4",
     "quote-stream": "^1.0.1",
     "resolve": "^1.1.5",
     "static-module": "^1.1.0",

--- a/readme.markdown
+++ b/readme.markdown
@@ -125,6 +125,8 @@ Optionally, you can set which `opts.vars` will be used in the
 [static argument evaluation](https://npmjs.org/package/static-eval)
 in addition to `__dirname` and `__filename`.
 
+Also, it's possible to define [minimatch](https://github.com/isaacs/minimatch) patterns against absolute paths in `opts.include` and `opts.exclude` to transform only a subset of source files.
+
 # events
 
 ## tr.on('file', function (file) {})
@@ -140,13 +142,13 @@ A tiny command-line program ships with this module to make debugging easier.
 usage:
 
   brfs file
- 
+
     Inline `fs.readFileSync()` calls from `file`, printing the transformed file
     contents to stdout.
 
   brfs
   brfs -
- 
+
     Inline `fs.readFileSync()` calls from stdin, printing the transformed file
     contents to stdout.
 


### PR DESCRIPTION
I have a project where I need to exclude certain source files from being transformed by brfs (due to various reasons). I found many issues where people have similar needs, e.g. #76 #70 #55 #41.

This pull request adds support for opts.include and opts.exclude, both taking a minimatch pattern, which is matched against the source file path being transformed. Minimatch was already a dependency by browserify#glob.

Usage examples:

`browserify -g [ brfs --exclude '**/node_modules/problematic/*' ] ...`
`browserify -g [ brfs --include '**/src/foo/bar/**' ] ...`

I also added [.editorconfig](http://editorconfig.org), which helps other contributors to maintain the formatting style of the project (e.g. disable whitespace trimming).