### PR TITLE
Update static-module to v3 with scope tracking.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   "dependencies": {
     "quote-stream": "^1.0.1",
     "resolve": "^1.1.5",
-    "static-module": "^2.2.0",
+    "static-module": "^3.0.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {
     "browserify": "^16.1.1",
     "concat-stream": "^1.6.0",
-    "tap": "~0.4.8",
+    "tap": "^10.7.3",
     "through": "^2.3.4"
   },
   "scripts": {


### PR DESCRIPTION
Fixes a security problem in a dependency.

  Moderate        Sandbox Breakout / Arbitrary Code Execution
  Package         static-eval
  Patched in      >=2.0.0
  Dependency of   brfs 
  Path            brfs > static-module > static-eval
  More info       https://nodesecurity.io/advisories/548

Fixes #76 
Fixes #71 