### PR TITLE
fix `input.js` file entries in source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ module.exports = function (file, opts) {
             vars: vars,
             varModules: { path: path },
             parserOpts: opts && opts.parserOpts,
-            sourceMap: opts && (opts.sourceMap || opts._flags && opts._flags.debug)
+            sourceMap: opts && (opts.sourceMap || opts._flags && opts._flags.debug),
+            inputFilename: file
         }
     );
     return sm;


### PR DESCRIPTION
Pass `inputFilename` to static module to make it insert proper file name
into generated source map.

Without this change we end up with 'input.js' (which is the default file name) as
the basename of affected files in the resulting source maps.

see also: browserify/common-shakeify#16