### PR TITLE
Replaces Buffer( by Buffer.from(

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = function (file, opts) {
         
         var stream = through(write, end);
         stream.push('process.nextTick(function(){(' + cb + ')(null,');
-        if (isBuffer) stream.push('Buffer(');
+        if (isBuffer) stream.push('Buffer.from(');
         
         var s = fs.createReadStream(file, { encoding: enc });
         s.on('error', function (err) { sm.emit('error', err) });


### PR DESCRIPTION
The `Buffer` constructor is deprecated for security reason; Node recommends using `Buffer.from()` instead in such situations. Until it's fixed, it'll print annoying warning messages.