### PR TITLE
Update static-module from 3.0.0 to 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "quote-stream": "^1.0.1",
     "resolve": "^1.1.5",
-    "static-module": "^3.0.0",
+    "static-module": "^3.0.2",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates `package.json` to use `static-module` version `3.0.2` instead of `3.0.01` since `static-module` has been updated to fix [vulnerability](https://github.com/browserify/static-eval/commit/32f8efd072625e267aa7237d2daff35738c50d2a).

@goto-bus-stop 