### PR TITLE
feat: add transform options to transform content

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -128,6 +128,12 @@ in addition to `__dirname` and `__filename`.
 `opts.parserOpts` can be used to configure the parser brfs uses,
 [acorn](https://github.com/acornjs/acorn#main-parser).
 
+`opts.readFileTransform` can be used to transform the filestream of
+the given file. For example you can minify the content.
+
+`opts.readFileSyncTransform` can be used to transform the filestream of
+the given file. For example you can minify the content.
+
 # events
 
 ## tr.on('file', function (file) {})


### PR DESCRIPTION
This pr adds 2 extra options to manipulate the file content that is read by the readFile functions. This allows you to modify content that is been returned by readFile & readFileSync.

The idea behind these transforms is that we can minify a js files with an uglify/terser transform.

I wasn't sure how to add tests for this behaviour. Also I would love to get some feedback on this change.